### PR TITLE
Add pytest markers for test categorization and improve clarity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,9 @@ testpaths = [
 ]
 pythonpath = "."
 markers = [
-    "success: marks tests as success cases",
-    "error: marks tests as error cases",
-    "edge_case: marks tests as edge cases",
+  "success: marks tests that verify expected behavior under normal conditions",
+  "error: marks tests that verify proper error handling and exception cases",
+  "edge_case: marks tests that verify behavior in edge or boundary conditions",
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ testpaths = [
   "tests", # テストファイルが置かれているディレクトリ
 ]
 pythonpath = "."
+markers = [
+    "success: marks tests as success cases",
+    "error: marks tests as error cases",
+    "edge_case: marks tests as edge cases",
+]
 
 [project]
 name = "python_template"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,7 +42,7 @@ def test_read_root():
     assert response.json() == {"Hello": "World"}
 
 
-@pytest.mark.edge_case
+@pytest.mark.success
 def test_list_files_empty(tmp_app_data_dir):
     response = client.get("/list_files")
     assert response.status_code == 200

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,18 +35,21 @@ def tmp_app_data_dir(tmp_path):  # Use pytest's tmp_path fixture
 client = TestClient(app)
 
 
+@pytest.mark.success
 def test_read_root():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"Hello": "World"}
 
 
+@pytest.mark.edge_case
 def test_list_files_empty(tmp_app_data_dir):
     response = client.get("/list_files")
     assert response.status_code == 200
     assert response.json() == {"files": []}
 
 
+@pytest.mark.success
 def test_write_and_read_file_success(tmp_app_data_dir):
     file_path = "test_dir/test_file.txt"
     file_content = "Hello, FastAPI!"
@@ -60,6 +63,7 @@ def test_write_and_read_file_success(tmp_app_data_dir):
     assert response.json() == {"content": file_content}
 
 
+@pytest.mark.success
 def test_list_files_with_content(tmp_app_data_dir):
     (tmp_app_data_dir / "file1.txt").write_text("content1")
     (tmp_app_data_dir / "subdir").mkdir(
@@ -79,6 +83,7 @@ def test_list_files_with_content(tmp_app_data_dir):
     assert len(files) == 3
 
 
+@pytest.mark.success
 def test_list_files_filter_extensions(tmp_app_data_dir):
     (tmp_app_data_dir / "file1.txt").write_text("content1")
     (tmp_app_data_dir / "file2.log").write_text("content2")
@@ -93,6 +98,7 @@ def test_list_files_filter_extensions(tmp_app_data_dir):
     assert len(files) == 2
 
 
+@pytest.mark.edge_case
 def test_list_files_max_items(tmp_app_data_dir):
     for i in range(5):
         (tmp_app_data_dir / f"file{i}.txt").write_text(f"content{i}")
@@ -103,11 +109,13 @@ def test_list_files_max_items(tmp_app_data_dir):
     assert len(files) == 2
 
 
+@pytest.mark.error
 def test_read_file_not_found(tmp_app_data_dir):
     response = client.get("/read_file?file_path=non_existent.txt")
     assert response.status_code == 404
 
 
+@pytest.mark.error
 def test_read_file_path_traversal(tmp_app_data_dir):
     # Create a dummy file outside the allowed BASE_DIR to simulate traversal target
     (Path(__file__).parent / "outside.txt").write_text("secret")
@@ -117,6 +125,7 @@ def test_read_file_path_traversal(tmp_app_data_dir):
     (Path(__file__).parent / "outside.txt").unlink()  # Clean up
 
 
+@pytest.mark.error
 def test_read_file_invalid_extension(tmp_app_data_dir):
     (tmp_app_data_dir / "image.jpg").write_bytes(b"dummy_image_data")
     response = client.get("/read_file?file_path=image.jpg")
@@ -124,6 +133,7 @@ def test_read_file_invalid_extension(tmp_app_data_dir):
     assert "Extension .jpg not allowed" in response.json()["detail"]
 
 
+@pytest.mark.error
 def test_write_file_path_traversal(tmp_app_data_dir):
     response = client.post(
         "/write_file?file_path=../evil.txt", json={"content": "malicious"}
@@ -132,6 +142,7 @@ def test_write_file_path_traversal(tmp_app_data_dir):
     assert "Path traversal detected" in response.json()["detail"]
 
 
+@pytest.mark.error
 def test_write_file_invalid_extension(tmp_app_data_dir):
     response = client.post(
         "/write_file?file_path=document.pdf", json={"content": "pdf content"}
@@ -140,6 +151,7 @@ def test_write_file_invalid_extension(tmp_app_data_dir):
     assert "Extension .pdf not allowed" in response.json()["detail"]
 
 
+@pytest.mark.error
 def test_write_file_payload_too_large(tmp_app_data_dir):
     large_content = "A" * (MAX_FILE_SIZE_BYTES + 1)  # Exceeds limit
     response = client.post(
@@ -149,6 +161,7 @@ def test_write_file_payload_too_large(tmp_app_data_dir):
     assert "File size exceeds" in response.json()["detail"]
 
 
+@pytest.mark.error
 def test_read_file_not_utf8(tmp_app_data_dir):
     # Create a file with non-UTF-8 content
     non_utf8_path = tmp_app_data_dir / "non_utf8.txt"
@@ -160,6 +173,7 @@ def test_read_file_not_utf8(tmp_app_data_dir):
     assert "File is not UTF-8 encoded" in response.json()["detail"]
 
 
+@pytest.mark.success
 def test_trace_id_propagation(tmp_app_data_dir):
     trace_id_value = "12345-abcde"
     file_path = "trace_test.txt"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -8,6 +8,7 @@ import src.orchestrator as orchestrator_module  # Import the module itself
 
 
 # --- Tests for extract_json_from_hermes_output ---
+@pytest.mark.success
 def test_extract_json_from_hermes_output_with_fences():
     hermes_output = """
     Some text before.
@@ -20,18 +21,21 @@ def test_extract_json_from_hermes_output_with_fences():
     assert result == {"thought": "hello", "tool_calls": []}
 
 
+@pytest.mark.success
 def test_extract_json_from_hermes_output_without_fences():
     hermes_output = '{"thought": "hello", "tool_calls": []}'
     result = orchestrator_module.extract_json_from_hermes_output(hermes_output)
     assert result == {"thought": "hello", "tool_calls": []}
 
 
+@pytest.mark.error
 def test_extract_json_from_hermes_output_invalid_json():
     hermes_output = "this is not json"
     with pytest.raises(orchestrator_module.JsonExtractionError):
         orchestrator_module.extract_json_from_hermes_output(hermes_output)
 
 
+@pytest.mark.error
 def test_extract_json_from_hermes_output_malformed_json_in_fences():
     hermes_output = """
     ```json
@@ -42,6 +46,7 @@ def test_extract_json_from_hermes_output_malformed_json_in_fences():
         orchestrator_module.extract_json_from_hermes_output(hermes_output)
 
 
+@pytest.mark.edge_case
 def test_extract_json_from_hermes_output_empty_fenced_json():
     hermes_output = """
     ```json
@@ -77,6 +82,7 @@ def mock_httpx_client():
 
 
 # --- Tests for execute_tool_call ---
+@pytest.mark.success
 @pytest.mark.asyncio
 async def test_execute_tool_call_list_files_success(mock_httpx_client):
     mock_httpx_client.get.return_value.status_code = 200
@@ -93,6 +99,7 @@ async def test_execute_tool_call_list_files_success(mock_httpx_client):
     assert result == {"files": ["a.txt"]}
 
 
+@pytest.mark.success
 @pytest.mark.asyncio
 async def test_execute_tool_call_read_file_success(mock_httpx_client):
     mock_httpx_client.get.return_value.status_code = 200
@@ -111,6 +118,7 @@ async def test_execute_tool_call_read_file_success(mock_httpx_client):
     assert result == {"content": "file content"}
 
 
+@pytest.mark.success
 @pytest.mark.asyncio
 async def test_execute_tool_call_write_file_success(mock_httpx_client):
     mock_httpx_client.post.return_value.status_code = 200
@@ -132,6 +140,7 @@ async def test_execute_tool_call_write_file_success(mock_httpx_client):
     assert result == {}  # Corrected assertion
 
 
+@pytest.mark.error
 @pytest.mark.asyncio
 async def test_execute_tool_call_write_file_missing_args(mock_httpx_client):
     tool_call = {
@@ -143,6 +152,7 @@ async def test_execute_tool_call_write_file_missing_args(mock_httpx_client):
         await orchestrator_module.execute_tool_call(tool_call, trace_id)
 
 
+@pytest.mark.error
 @pytest.mark.asyncio
 async def test_execute_tool_call_unsupported_tool(mock_httpx_client):
     tool_call = {"tool_name": "unsupported_tool", "args": {}}
@@ -153,6 +163,7 @@ async def test_execute_tool_call_unsupported_tool(mock_httpx_client):
         await orchestrator_module.execute_tool_call(tool_call, trace_id)
 
 
+@pytest.mark.error
 @pytest.mark.asyncio
 async def test_execute_tool_call_mcp_http_error(mock_httpx_client):
     mock_response = AsyncMock(spec=httpx.Response)  # spec を追加
@@ -172,6 +183,7 @@ async def test_execute_tool_call_mcp_http_error(mock_httpx_client):
         await orchestrator_module.execute_tool_call(tool_call, trace_id)
 
 
+@pytest.mark.error
 @pytest.mark.asyncio
 async def test_execute_tool_call_mcp_connection_error(mock_httpx_client):
     # No need to mock raise_for_status here, as RequestError is caught earlier
@@ -189,6 +201,7 @@ async def test_execute_tool_call_mcp_connection_error(mock_httpx_client):
 
 
 # --- Tests for orchestrate ---
+@pytest.mark.success
 @pytest.mark.asyncio
 async def test_orchestrate_success(mock_httpx_client):
     mock_httpx_client.post.return_value.status_code = 200
@@ -218,6 +231,7 @@ async def test_orchestrate_success(mock_httpx_client):
     assert mock_httpx_client.get.call_count == 1
 
 
+@pytest.mark.error
 @pytest.mark.asyncio
 async def test_orchestrate_json_extraction_error():
     hermes_output = "invalid json"
@@ -225,6 +239,7 @@ async def test_orchestrate_json_extraction_error():
     assert exit_code == 3
 
 
+@pytest.mark.error
 @pytest.mark.asyncio
 async def test_orchestrate_policy_error(mock_httpx_client):
     hermes_output = """
@@ -242,6 +257,7 @@ async def test_orchestrate_policy_error(mock_httpx_client):
     assert exit_code == 2
 
 
+@pytest.mark.error
 @pytest.mark.asyncio
 async def test_orchestrate_execution_error(mock_httpx_client):
     mock_response = AsyncMock()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -46,7 +46,7 @@ def test_extract_json_from_hermes_output_malformed_json_in_fences():
         orchestrator_module.extract_json_from_hermes_output(hermes_output)
 
 
-@pytest.mark.edge_case
+@pytest.mark.error
 def test_extract_json_from_hermes_output_empty_fenced_json():
     hermes_output = """
     ```json


### PR DESCRIPTION
Enhance test suite structure and readability by introducing pytest markers for categorizing test cases into success, error, and edge cases. Register custom markers in the pyproject.toml file to suppress warnings and ensure proper recognition. This change allows for selective test execution based on categories, improving the flexibility and efficiency of the testing process. Closes #1